### PR TITLE
Fix shade warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,20 @@
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
+					<filters>
+						 <filter>
+							<artifact>xerces:*</artifact>
+							 <excludes>
+								 <exclude>META-INF/*.MF</exclude>
+							</excludes>
+						</filter>
+						 <filter>
+							<artifact>xml-apis:*</artifact>
+							 <excludes>
+								 <exclude>META-INF/*.MF</exclude>
+							</excludes>
+						</filter>
+					</filters>
 					<transformers>
 						<transformer
 							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
This fixes the following warning:

```
concrete_cif-0.0.0-SNAPSHOT.jar, xercesImpl-2.12.0.jar, xml-apis-1.4.01.jar define 1 overlapping resource:
  - META-INF/MANIFEST.MF
```